### PR TITLE
Add support for an "overview" documentation section. Fix the title of the generated docs.

### DIFF
--- a/lib/calamum/definition_parser.rb
+++ b/lib/calamum/definition_parser.rb
@@ -19,6 +19,10 @@ class Calamum::DefinitionParser
     @definition['url']
   end
 
+  def get_description
+    @definition['description']
+  end
+
   def get_resources_names
     @definition['resources'].inject([]){|resources, (key, content)| resources << key}
   end

--- a/lib/calamum/doc_generator.rb
+++ b/lib/calamum/doc_generator.rb
@@ -1,13 +1,14 @@
 
 class Calamum::DocGenerator
   include ERB::Util
-  attr_accessor :resources, :templaete, :name, :url
+  attr_accessor :resources, :template, :name, :url, :description
 
-  def initialize(template, resources, name, url)
+  def initialize(template, resources, name, url, descr)
     @template = template
     @resources = resources
     @name = name
     @url = url
+    @description = descr
   end
 
   def render()

--- a/lib/calamum/runner.rb
+++ b/lib/calamum/runner.rb
@@ -61,7 +61,8 @@ class Calamum::Runner
     @definition = Calamum::DefinitionParser.new(api_definition)
     @definition.load_requests
     template = Calamum::DocGenerator.load_template
-    html_output = Calamum::DocGenerator.new(template, @definition.resources, @definition.get_name, @definition.get_url)
+    html_output = Calamum::DocGenerator.new(template,
+        @definition.resources, @definition.get_name, @definition.get_url, @definition.get_description)
     html_output.save_result(File.join(Calamum::Config[:path], 'doc', 'index.html'))
   end
 

--- a/lib/calamum/templates/bootstrap/index.html.erb
+++ b/lib/calamum/templates/bootstrap/index.html.erb
@@ -24,8 +24,14 @@
 <div class="row">
 <div class="span3 bs-docs-sidebar">
   <ul class="nav nav-list bs-docs-sidenav affix-top">
+    <% if description %>
+    <li class="active">
+    <a href="#overview">
+    <i class="icon-chevron-right"></i>Overview</a>
+    </li>
+    <% end %>
     <% @resources.keys.each_with_index do |key,index| %>
-    <li class="<%= index == 0 ? 'active': '' %>">
+    <li class="<%= !description && (index == 0) ? 'active': '' %>">
     <a href="#<%= key %>_section">
     <i class="icon-chevron-right"></i><%= key %></a>
     </li>
@@ -33,6 +39,16 @@
   </ul>
 </div>
 <div class="span9">
+  <% if description %>
+  <section id="overview">
+    <div class="page-header">
+      <h2>Overview</h2>
+    </div>
+    <div id="overview-body">
+    <%= description %>
+    </div>
+  </section>
+  <% end %>
   <% @resources.each do |name, requests| %>
   <section id="<%= name %>_section">
     <div class="page-header">


### PR DESCRIPTION
Hope these changes are of interest. When documenting an API I wanted to be able to document general behaviours that aren't specific to a particular call (auth, field filtering, output format and so on) and also to give a feel for how the various calls fit together - these go into the top-level "Overview" section.
