### PR TITLE
Add the ability to include an example request

### DIFF
--- a/lib/calamum/resource.rb
+++ b/lib/calamum/resource.rb
@@ -3,7 +3,7 @@
 # So anywhere in view template we can use this object.
 class Calamum::Resource
   attr_accessor :uri, :action, :headers,
-    :auth, :params, :errors, :description, :response, :tryit
+    :auth, :params, :errors, :description, :request, :response, :tryit
 
   # Initialize object from attributes.
   #
@@ -16,6 +16,7 @@ class Calamum::Resource
     @params = attrs['params'] || {}
     @errors = attrs['errors'] || {}
     @description = attrs['description']
+    @request = attrs['request']
     @response = attrs['response']
     @tryit = attrs['tryit']
   end

--- a/lib/calamum/templates/twitter/view.html.erb
+++ b/lib/calamum/templates/twitter/view.html.erb
@@ -60,6 +60,15 @@
             </div>
           </div>
 
+          <% if @resource.request %>
+            <div class="group-example-request">
+              <h2>Example Request</h2>
+              <div class="content">
+                <pre class="prettyprint"><%= pj @resource.request %></pre>
+              </div>
+            </div>
+          <% end %>
+
           <% if @resource.response %>
             <div class="group-example-request">
               <h2>Example Response</h2>

--- a/sample/sample.json
+++ b/sample/sample.json
@@ -116,6 +116,11 @@
                         "required": false
                     }
                 },
+                "request": {
+                    "email": "jdoe@gmail.com",
+                    "first_name": "John",
+                    "last_name": "Doe"
+                },
                 "response": {
                     "id": 207119551,
                     "first_name": "John",
@@ -152,6 +157,13 @@
                         "description": "Additional note for user",
                         "required": false
                     }
+                },
+                "request": {
+                    "id": 207119551,
+                    "email": "jdoe@gmail.com",
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "note": "Note has been updated"
                 },
                 "response": {
                     "id": 207119551,

--- a/sample/sample.yml
+++ b/sample/sample.yml
@@ -66,10 +66,6 @@ resources:
         content_type: 'application/json'
         content_language: 'en-US'
       params:
-        id: 
-          type: 'String'
-          description: 'User id'
-          required: true
         name:
           type: 'String'
           description: 'User name'
@@ -78,6 +74,8 @@ resources:
           type: 'String'
           description: 'User email'
           required: true
+      request: {"name": "test", "mail": "test@test.com"}
+      response: {"id": 12345, "name": "test", "mail": "test@test.com"}
      -
       uri: '/users/:id'
       action: 'put'
@@ -86,7 +84,7 @@ resources:
         content_type: 'application/json'
         content_language: 'en-US'
       params:
-        id: 
+        id:
           type: 'String'
           description: 'User id'
           required: true
@@ -98,6 +96,8 @@ resources:
           type: 'String'
           description: 'User email'
           required: true
+      request: {"id": 12345, "name": "test", "mail": "test@test.com"}
+      response: {"id": 12345, "name": "test", "mail": "test@test.com"}
      -
       uri: '/users/:id'
       action: 'delete'


### PR DESCRIPTION
This adds the ability to include an example request JSON as well.

```json
      "request": {
        "name": "AwesomeSauce"
      }
```

![screen shot 2015-04-27 at 11 29 21 am](https://cloud.githubusercontent.com/assets/508237/7351016/ae538886-ecd0-11e4-85ed-916834f69b95.png)