### PR TITLE
Set title, copyright, minor UI fixes

### DIFF
--- a/lib/calamum/doc_parser.rb
+++ b/lib/calamum/doc_parser.rb
@@ -18,6 +18,10 @@ class Calamum::DocParser
     @definition['version']
   end
 
+  def get_copyright
+    @definition['copyright']
+  end
+
   def get_authentication
     @definition['authentication']
   end

--- a/lib/calamum/runner.rb
+++ b/lib/calamum/runner.rb
@@ -96,7 +96,8 @@ class Calamum::Runner
       :name => @definition.get_name,
       :resources => @definition.resources,
       :description => @definition.get_description,
-      :version => @definition.get_version
+      :version => @definition.get_version,
+      :copyright => @definition.get_copyright
     }
 
     page = Calamum::DocGenerator.new(:index)
@@ -110,6 +111,7 @@ class Calamum::Runner
       :name => @definition.get_name,
       :version => @definition.get_version,
       :description => content,
+      :copyright => @definition.get_copyright
     }
     page = Calamum::DocGenerator.new(:section)
     page.save_template("#{section}.html", bindings)

--- a/lib/calamum/templates/bootstrap/index.html.erb
+++ b/lib/calamum/templates/bootstrap/index.html.erb
@@ -65,12 +65,13 @@
       </div>
       <div id="<%= req.slug %>" class="accordion-body collapse">
       <div class="accordion-inner">
-	<ul class="nav nav-tabs">
-	  <li class="active"><a href="#description_<%= req.slug %>"  data-toggle="tab">Description</a></li>
-	  <li><a href="#header_<%= req.slug %>" data-toggle="tab">Header</a></li>
-	  <li><a href="#params_<%= req.slug %>" data-toggle="tab">Parameters</a></li>
-	  <li><a href="#response_<%= req.slug %>" data-toggle="tab">Response</a></li>
-	</ul>
+      	<ul class="nav nav-tabs">
+      	  <li class="active"><a href="#description_<%= req.slug %>"  data-toggle="tab">Description</a></li>
+      	  <li><a href="#header_<%= req.slug %>" data-toggle="tab">Header</a></li>
+      	  <li><a href="#params_<%= req.slug %>" data-toggle="tab">Parameters</a></li>
+          <li><a href="#request_<%= req.slug %>" data-toggle="tab">Request</a></li>
+      	  <li><a href="#response_<%= req.slug %>" data-toggle="tab">Response</a></li>
+      	</ul>
         <div class="tab-content">
 	 <div class="tab-pane active" id="description_<%= req.slug %>"><%= req.description %></div>
 	 <div class="tab-pane" id="header_<%= req.slug %>">
@@ -121,11 +122,16 @@
 	      Request without parameters
 	   <% end %>
 	 </div>
-	   <div class="tab-pane content" id="response_<%= req.slug %>">
-		<% if req.response %>
-	  	 <pre class="prettyprint"><%= pj req.response %></pre>
-		 <% end%>
-	   </div>
+    <div class="tab-pane content" id="request_<%= req.slug %>">
+    <% if req.request %>
+    	 <pre class="prettyprint"><%= pj req.request %></pre>
+    <% end%>
+   </div>
+    <div class="tab-pane content" id="response_<%= req.slug %>">
+    <% if req.response %>
+       <pre class="prettyprint"><%= pj req.response %></pre>
+    <% end%>
+      </div>
         </div>
        </div>
      </div>

--- a/lib/calamum/templates/twitter/assets/css/main.css
+++ b/lib/calamum/templates/twitter/assets/css/main.css
@@ -1043,6 +1043,7 @@ pre.prettyprint  {
     padding: 0px;
      background-color: #fafafb;
      border: none !important;
+     overflow-y: auto;
 }
  pre .str  {
     color: #36C;

--- a/lib/calamum/templates/twitter/errors.html.erb
+++ b/lib/calamum/templates/twitter/errors.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Developers API</title>
+    <title><%= @name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link type="text/css" rel="stylesheet" href="assets/css/main.css" />
   </head>

--- a/lib/calamum/templates/twitter/index.html.erb
+++ b/lib/calamum/templates/twitter/index.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Developers API</title>
+    <title><%= @name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link type="text/css" rel="stylesheet" href="assets/css/main.css" />
   </head>
@@ -27,7 +27,7 @@
             <table>
               <caption>
                 <strong><%= name.capitalize %></strong>
-                <p>This endpoints belong to <%= name %> resource.</p>
+                <p>These endpoints belong to the <%= name %> resource.</p>
               </caption>
               <thead>
                 <tr>
@@ -53,7 +53,7 @@
       </div>
 
       <div id="footer-outer">
-        <div id="footer"><%= @name %> &copy; 2013</div>
+        <div id="footer"><%= @name %> &copy; <%= @copyright || '2015' %></div>
       </div>
 
     </div>

--- a/lib/calamum/templates/twitter/section.html.erb
+++ b/lib/calamum/templates/twitter/section.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Developers API</title>
+    <title><%= @name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link type="text/css" rel="stylesheet" href="assets/css/main.css" />
   </head>
@@ -29,7 +29,7 @@
       </div>
 
       <div id="footer-outer">
-        <div id="footer"><%= @name %> &copy; 2013</div>
+        <div id="footer"><%= @name %> &copy; <%= @copyright || '2015' %></div>
       </div>
     </div>
   </body>

--- a/sample/sample_separate_resources.json
+++ b/sample/sample_separate_resources.json
@@ -3,5 +3,6 @@
     "url": "http://api.sample.com",
     "version": "1.0",
     "description": "Calamum is a simple ruby build program to generate a REST API documentation from a YAML file definition",
-    "resources": "./resources"
+    "resources": "./resources",
+    "copyright": "2015"
 }


### PR DESCRIPTION
A few minor UI enhancements:
- Set title to @name for index and sections in the twitter template
- Set the copyright date from the JSON, default to 2015
- Add the request example to the bootstrap template (missing in PR https://github.com/malachheb/calamum/pull/15) 
- Allow the request/response examples to scroll horizontally instead of overflowing the grey box

Thanks for the useful project!
