### PR TITLE
Add support for custom templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tmtags
 ## VIM
 *.swp
 
+## Rubymine
+.idea
+
 ## PROJECT::GENERAL
 tmp
 pkg

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Usage: /bin/calamum (options)
   -f, --file DEFINITION            Path to the file with API definition
   -p, --path PATH                  Path to the directory where docs will be generated
   -t, --template TEMPLATE          Name of HTML template (twitter or bootstrap , twitter by default)
+  -l, --tplpath TEMPLATE_PATH      Path to look for templates.
   -s, --sort                       Sort the resources alphabetically
   -v, --version                    Show version number
   -h, --help                       Show this help
@@ -32,8 +33,16 @@ for bootstrap template:
 	
 	$calamum -f my_api_definition.json -t bootstrap
 
+for your owm template (in some/other/dir/mytemplate):
+
+	$calamum -f my_api_definition.json -l some/other/dir -t mytemplate
+
 To preview just generated documentation, navigate to the 'docs' directory (by default in your home path, you can specify the destination path with the option '-p/--path').
 Then, find and open the index.html file in your browser and enjoy the result.
+
+## Custom template
+
+Currently, custom templates are based on the `twitter` template format.  The simplest way to create your own template is to copy that one and modify it.
 
 ## Inspirations
 - [Apiary](http://apiary.io/blueprint)

--- a/lib/calamum.rb
+++ b/lib/calamum.rb
@@ -10,5 +10,4 @@ module Calamum
   require 'calamum/doc_parser'
   require 'calamum/doc_generator'
   require 'calamum/version'
-  VALID_TEMPLATES = %{twitter bootstrap}
 end

--- a/lib/calamum/config.rb
+++ b/lib/calamum/config.rb
@@ -13,11 +13,10 @@ class Calamum::Config
     merge!(config)
 
     self.doc_path = File.join(config[:path], 'docs')
-    self.tpl_path = File.join(File.dirname(__FILE__),
-                              'templates',
-                              config[:template])
-    unless Calamum::VALID_TEMPLATES.include?(config[:template])
-      fail "Unknown template #{config[:template]}"
+    self.tpl_path = File.join(config[:tplpath], config[:template])
+
+    unless File.exist?(self.tpl_path)
+      fail "Cannot find template #{config[:template]}"
     end
   end
 end

--- a/lib/calamum/runner.rb
+++ b/lib/calamum/runner.rb
@@ -26,8 +26,14 @@ class Calamum::Runner
   option :template,
     :short        => '-t TEMPLATE',
     :long         => '--template TEMPLATE',
-    :description  => 'Name of HTML template [twitter, bootstrap](twitter by default)',
+    :description  => 'Name of HTML template [twitter, bootstrap, custom](twitter by default)',
     :default      => 'twitter'
+
+  option :tplpath,
+    :short        => '-l TEMPLATE_PATH',
+    :long         => '--tplpath TEMPLATE_PATH',
+    :description  => 'Path to look for templates.',
+    :default      => File.join(File.dirname(__FILE__), 'templates')
 
   option :path,
     :short        => '-p PATH',
@@ -51,9 +57,9 @@ class Calamum::Runner
     :exit         => 0
 
   option :sort,
-    :short        => "-s",
-    :long         => "--sort",
-    :description  => "Sort the resources alphabetically",
+    :short        => '-s',
+    :long         => '--sort',
+    :description  => 'Sort the resources alphabetically',
     :boolean      => true,
     :default      => false
 
@@ -67,7 +73,7 @@ class Calamum::Runner
     Calamum::DocGenerator.init_base_dir
     process_index
 
-    if config[:template] == 'twitter'
+    unless config[:template] == 'bootstrap'
       process_pages
       process_section("overview",  @definition.get_description)
       process_section("authentication", @definition.get_authentication)


### PR DESCRIPTION
This adds support for a custom template path and assumes you are using the twitter template as a base since it includes the `overview` and `authorization` sections.

Sorry for the multiple PRs, we are just starting to use this and find it very useful!  Thanks again!